### PR TITLE
Fix issues with rendering RDS inventory as a table + EKS support

### DIFF
--- a/lib/aws-inventory.rb
+++ b/lib/aws-inventory.rb
@@ -21,6 +21,7 @@ module AwsInventory
   autoload :Elb, "aws_inventory/elb"
   autoload :Eb, "aws_inventory/eb"
   autoload :Ecs, "aws_inventory/ecs"
+  autoload :Eks, "aws_inventory/eks"
   autoload :Keypair, "aws_inventory/keypair"
   autoload :Iam, "aws_inventory/iam"
   autoload :Cloudwatch, "aws_inventory/cloudwatch"

--- a/lib/aws_inventory/aws_services.rb
+++ b/lib/aws_inventory/aws_services.rb
@@ -43,6 +43,10 @@ module AwsInventory::AwsServices
     @ecs ||= Aws::ECS::Client.new
   end
 
+  def eks
+    @eks ||= Aws::EKS::Client.new
+  end
+
   def iam
     @iam ||= Aws::IAM::Client.new
   end

--- a/lib/aws_inventory/cli.rb
+++ b/lib/aws_inventory/cli.rb
@@ -65,6 +65,12 @@ module AwsInventory
       Ecs.new(options).report
     end
 
+    desc "eks", "report eks inventory"
+    long_desc Help.text(:eks)
+    def eks
+      Eks.new(options).report
+    end
+
     desc "keypair", "report keypair inventory"
     long_desc Help.text(:keypair)
     def keypair

--- a/lib/aws_inventory/eks.rb
+++ b/lib/aws_inventory/eks.rb
@@ -1,0 +1,11 @@
+class AwsInventory::Eks < AwsInventory::Base
+  autoload :Cluster, "aws_inventory/eks/cluster"
+  autoload :Nodegroup, "aws_inventory/eks/nodegroup"
+
+  # Override report
+  def report
+    Cluster.new(@options).report
+    Nodegroup.new(@options).report
+
+  end
+end

--- a/lib/aws_inventory/eks/cluster.rb
+++ b/lib/aws_inventory/eks/cluster.rb
@@ -1,0 +1,23 @@
+class AwsInventory::Eks::Cluster < AwsInventory::Base
+  def header
+    ["Cluster", "ARN", "Version", "Tags"]
+  end
+
+  def data
+    eks_clusters.map do |cluster|
+      [
+        cluster.name,
+        cluster.arn,
+        "#{cluster.version} #{cluster.platform_version}",
+        cluster.tags.to_s,
+      ]
+    end
+  end
+
+  def eks_clusters
+    cluster_names = eks.list_clusters.clusters
+    cluster_names.map do |cluster_name|
+      eks.describe_cluster(name: cluster_name).cluster
+    end
+  end
+end

--- a/lib/aws_inventory/eks/nodegroup.rb
+++ b/lib/aws_inventory/eks/nodegroup.rb
@@ -1,0 +1,31 @@
+class AwsInventory::Eks::Nodegroup < AwsInventory::Base
+  def header
+    ["Cluster", "Nodegroup", "Version", "Capacity Type", "Scaling Config", "Node Role", "Labels", "Tags"]
+  end
+
+  def data
+    eks_nodegroups.map do |nodegroup|
+      [
+        nodegroup.cluster_name,
+        nodegroup.nodegroup_name,
+        "#{nodegroup.version} #{nodegroup.release_version}",
+        nodegroup.capacity_type,
+        nodegroup.scaling_config.to_s,
+        nodegroup.node_role,
+        nodegroup.labels.to_s,
+        nodegroup.tags.to_s,
+      ]
+    end
+  end
+
+  def eks_nodegroups
+    cluster_names = eks.list_clusters.clusters
+    cluster_names.map do |cluster_name|
+      nodegroups = eks.list_nodegroups(cluster_name: cluster_name).nodegroups
+      nodegroups.map do |nodegroup|
+        resp = eks.describe_nodegroup(cluster_name: cluster_name, nodegroup_name:nodegroup)
+        resp.nodegroup
+      end.flatten
+    end.flatten
+  end
+end

--- a/lib/aws_inventory/rds/shared.rb
+++ b/lib/aws_inventory/rds/shared.rb
@@ -8,7 +8,7 @@ module AwsInventory::Rds::Shared
     vpc_ids.map do |vpc_id|
       pretty_vpc_name = lookup_vpc_name(vpc_id)
       "#{vpc_id} (#{pretty_vpc_name})"
-    end
+    end.join(', ')
   end
 
   def lookup_vpc_name(vpc_id)
@@ -22,7 +22,7 @@ module AwsInventory::Rds::Shared
 
   def pretty_vpc_security_group(db)
     groups = vpc_security_groups(db)
-    groups.map { |g| "#{g.group_id} (#{g.group_name})" }
+    groups.map { |g| "#{g.group_id} (#{g.group_name})" }.join(', ')
   end
 
   # pretty name of the vpc security groups

--- a/lib/aws_inventory/rds/summary.rb
+++ b/lib/aws_inventory/rds/summary.rb
@@ -3,15 +3,15 @@ class AwsInventory::Rds
     include Shared
 
     def header
-      ["Name", "Engine", "Instance Class", "Publicly Accessible", "VPC", "Security Groups"]
+      ["DB Identifier", "Engine", "Instance Class", "Publicly Accessible", "VPC", "Security Groups"]
       #
     end
 
     def data
       db_instances.map do |db|
         [
-          db.db_name,
-          db.engine,
+          db.db_instance_identifier,
+          "#{db.engine} #{db.engine_version}",
           db.db_instance_class,
           db.publicly_accessible ? "yes" : "no",
           vpc_name(db),


### PR DESCRIPTION
Currently the RDS inventory throws an error. It can't be rendered because the vpc_name and security_group fields are returning a list. Joining these into a single string seems to do the trick.

Additionally, it is much more useful for matching purposes to show the DB Identifier rather than the db name (DB Identifier is what is shown in RDS console).

Update:
This PR now also includes the ability to report on EKS clusters.